### PR TITLE
Allow /delegates api query to return 201 results

### DIFF
--- a/packages/core-api/src/handlers/delegates/schema.ts
+++ b/packages/core-api/src/handlers/delegates/schema.ts
@@ -63,6 +63,11 @@ export const index: object = {
                 .integer()
                 .min(0),
         },
+        // Main delegates query needs to be able to return all active delegates
+        limit: Joi.number()
+            .integer()
+            .min(1)
+            .max(201),
     },
 };
 


### PR DESCRIPTION
Fix allows the explorer to work properly